### PR TITLE
Add option to emulate holding a button while turn signals are active

### DIFF
--- a/boxflat/hid_handler.py
+++ b/boxflat/hid_handler.py
@@ -315,6 +315,7 @@ class HidHandler(EventDispatcher):
             if number in MOZA_SIGNAL_RANGE:
                 if self._stalks_turnsignal_compat_constant:
                     self._turnsignal_compat_constant_handler(number)
+
                 elif self._stalks_turnsignal_compat:
                     self._turnsignal_compat_handler(number)
 
@@ -545,6 +546,7 @@ class HidHandler(EventDispatcher):
     def stalks_turnsignal_compat_active(self, active: bool) -> None:
         self._stalks_turnsignal_compat = bool(active)
 
+
     def stalks_turnsignal_compat_constant_active(self, active: bool) -> None:
         if not active:
             self._turnsignal_compat_constant_handler(MOZA_SIGNAL_CANCEL)
@@ -578,6 +580,7 @@ class HidHandler(EventDispatcher):
 
         Thread(daemon=True, target=self._turnsignal_compat_worker, args=[button]).start()
 
+
     def _turnsignal_compat_constant_handler(self, button: int) -> None:
         if self._turnsignal_last_button != button:
             Thread(daemon=True, target=self._turnsignal_compat_constant_worker, args=[
@@ -585,6 +588,7 @@ class HidHandler(EventDispatcher):
             ]).start()
 
             self._turnsignal_last_button = button
+
 
     def _wipers_compat_handler(self, button: int, headlights=False) -> None:
         last = self._last_headlight_button if headlights else self._last_wiper_button
@@ -634,6 +638,7 @@ class HidHandler(EventDispatcher):
             device.write(EV_SYN, SYN_REPORT, 0)
             sleep(0.05)
 
+
     def _turnsignal_compat_constant_worker(self, prev_button: int, button: int, blip: bool = False) -> None:
         with self._turnsignal_compat_worker_active:
             try:
@@ -661,6 +666,7 @@ class HidHandler(EventDispatcher):
                 device.write(EV_KEY, code, 1)
                 device.write(EV_SYN, SYN_REPORT, 0)
                 sleep(0.05)
+
 
     def _wipers_compat_worker(self, button: int, last: int, headlights=False) -> None:
         button_range = MOZA_HEADLIGHTS_RANGE if headlights else MOZA_WIPERS_RANGE

--- a/boxflat/hid_handler.py
+++ b/boxflat/hid_handler.py
@@ -546,6 +546,9 @@ class HidHandler(EventDispatcher):
         self._stalks_turnsignal_compat = bool(active)
 
     def stalks_turnsignal_compat_constant_active(self, active: bool) -> None:
+        if not active:
+            self._turnsignal_compat_constant_handler(MOZA_SIGNAL_CANCEL)
+
         self._stalks_turnsignal_compat_constant = bool(active)
 
 

--- a/boxflat/panels/stalks.py
+++ b/boxflat/panels/stalks.py
@@ -27,12 +27,12 @@ class StalksSettings(SettingsPanel):
     def prepare_ui(self):
         self.add_preferences_group("Compatibility modes")
 
-        self._add_row(BoxflatSwitchRow("Turn Signals (toggle)", "Press button again when canceling"))
+        self._add_row(BoxflatSwitchRow("Turn Signals toggle", "Press button again when canceling"))
         self._current_row.subscribe(self._settings.write_setting, "stalks-turnsignal-compat")
         self._current_row.subscribe(self._hid_handler.stalks_turnsignal_compat_active)
         self._current_row.set_value(self._settings.read_setting("stalks-turnsignal-compat") or 0, mute=False)
 
-        self._add_row(BoxflatSwitchRow("Turn Signals (hold)", "Hold button as long as signal is active"))
+        self._add_row(BoxflatSwitchRow("Turn Signals hold", "Hold button as long as signal is active"))
         self._current_row.subscribe(self._settings.write_setting, "stalks-turnsignal-compat-constant")
         self._current_row.subscribe(self._hid_handler.stalks_turnsignal_compat_constant_active)
         self._current_row.set_value(self._settings.read_setting("stalks-turnsignal-compat-constant") or 0, mute=False)

--- a/boxflat/panels/stalks.py
+++ b/boxflat/panels/stalks.py
@@ -27,10 +27,15 @@ class StalksSettings(SettingsPanel):
     def prepare_ui(self):
         self.add_preferences_group("Compatibility modes")
 
-        self._add_row(BoxflatSwitchRow("Turn Signals", "Press button again when canceling"))
+        self._add_row(BoxflatSwitchRow("Turn Signals (toggle)", "Press button again when canceling"))
         self._current_row.subscribe(self._settings.write_setting, "stalks-turnsignal-compat")
         self._current_row.subscribe(self._hid_handler.stalks_turnsignal_compat_active)
         self._current_row.set_value(self._settings.read_setting("stalks-turnsignal-compat") or 0, mute=False)
+
+        self._add_row(BoxflatSwitchRow("Turn Signals (hold)", "Hold button as long as signal is active"))
+        self._current_row.subscribe(self._settings.write_setting, "stalks-turnsignal-compat-constant")
+        self._current_row.subscribe(self._hid_handler.stalks_turnsignal_compat_constant_active)
+        self._current_row.set_value(self._settings.read_setting("stalks-turnsignal-compat-constant") or 0, mute=False)
 
         self.add_preferences_group()
         self._add_row(BoxflatSwitchRow("Headlights", "Cycling instead of discrete buttons"))


### PR DESCRIPTION
I've used this in Beam.NG and Assetto Corsa (AC Evo also has an option to choose between toggle and hold for button inputs). I prefer holding the button rather than toggling because it's less prone to getting out of sync with the game.

This can be combined with the existing compatibility setting for turn signals. In that case, an additional short button press is added when turning off the signal. This can be used to avoid desync in games that only support toggle and have a feature to automatically cancel turn signals. 

(Might need to change the UI description to clarify how the two options interact)