### PR TITLE
Update udev check to include /usr/lib/udev/rules.d

### DIFF
--- a/boxflat/app.py
+++ b/boxflat/app.py
@@ -83,7 +83,7 @@ class MainWindow(Adw.ApplicationWindow):
 
 
     def _check_native(self) -> bool:
-        return os.path.isfile("/etc/udev/rules.d/99-boxflat.rules")
+        return os.path.isfile("/etc/udev/rules.d/99-boxflat.rules") or os.path.isfile("/usr/lib/udev/rules.d/99-boxflat.rules")
 
 
     def _check_flatpak(self) -> bool:


### PR DESCRIPTION
I am currently in the process of packaging Boxflat for Void Linux (pull request [#55186](https://github.com/void-linux/void-packages/pull/55186)). In doing so, I had to install the udev rules under `/usr/lib/udev/rules.d` instead of `/etc/udev/rules.d`. While everything worked flawlessly, I always got a warning popup whenever I launched the app.

This PR fixes this behaviour by checking in both locations for the file 99-boxflat.rules. I only modified `_check_native()` and left `_check_flatpak()` untouched.

In my initial package submission I fixed this through a quick [patch](https://github.com/sornig/void-packages/blob/new-boxflat/srcpkgs/boxflat/patches/fix-udev-native-detection.patch), which I intend to remove again when this gets merged and included in the next release.