### PR TITLE
Allow users to disable detection fix for Moza devices

### DIFF
--- a/boxflat/app.py
+++ b/boxflat/app.py
@@ -146,6 +146,8 @@ class MyApp(Adw.Application):
         self._data_path = data_path
         self._held = Event()
 
+        self._hid_handler.set_detection_fix_enabled(self._settings.read_setting("moza-detection-fix-enabled") or True)
+
         self._cm = MozaConnectionManager(os.path.join(data_path, "serial.yml"), dry_run)
         self._cm.subscribe("hid-device-connected", self._hid_handler.add_device)
         self._cm.subscribe("hid-device-disconnected", self._hid_handler.remove_device)

--- a/boxflat/app.py
+++ b/boxflat/app.py
@@ -141,12 +141,15 @@ class MyApp(Adw.Application):
         Gtk.StyleContext.add_provider_for_display(Gdk.Display.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         self._settings = SettingsHandler(config_path)
+        if self._settings.read_setting("moza-detection-fix-enabled") is None:
+            self._settings.write_setting(1, "moza-detection-fix-enabled")
+
         self._hid_handler = HidHandler()
+        self._hid_handler.set_detection_fix_enabled(self._settings.read_setting("moza-detection-fix-enabled"))
+
         self._config_path = config_path
         self._data_path = data_path
         self._held = Event()
-
-        self._hid_handler.set_detection_fix_enabled(self._settings.read_setting("moza-detection-fix-enabled") or True)
 
         self._cm = MozaConnectionManager(os.path.join(data_path, "serial.yml"), dry_run)
         self._cm.subscribe("hid-device-connected", self._hid_handler.add_device)

--- a/boxflat/hid_handler.py
+++ b/boxflat/hid_handler.py
@@ -211,6 +211,7 @@ class HidHandler(EventDispatcher):
         self._stalks_wipers_compat_active = Lock()
 
         self._stalks_wipers_quick = False
+        self._detection_fix = False
 
 
     def __del__(self):
@@ -266,6 +267,16 @@ class HidHandler(EventDispatcher):
         pattern = f"{pattern}_2"
         if pattern in self._shutdowns:
             self._shutdowns[pattern].set()
+
+
+    def set_detection_fix_enabled(self, enabled: bool) -> None:
+        self._detection_fix = enabled
+
+        for pattern in self._devices.keys():
+            if pattern == MozaHidDevice.STALKS:
+                continue
+
+            self._detection_fix(pattern, enabled)
 
 
     def _configure_device(self, device: evdev.InputDevice, pattern: str):
@@ -412,7 +423,7 @@ class HidHandler(EventDispatcher):
         shutdown = Event()
         self._shutdowns[pattern] = shutdown
 
-        self.detection_fix(pattern)
+        self.detection_fix(pattern, True if pattern == MozaHidDevice.STALKS else self._detection_fix)
         device_path = device.path
         name = device.name
 
@@ -479,7 +490,16 @@ class HidHandler(EventDispatcher):
             cap[EV_KEY] = [BTN_JOYSTICK]
 
         # Create new device
-        new_device = evdev.UInput(cap, vendor=device.info.vendor, product=device.info.product, name=device.name)
+        name = device.name
+        vendor = device.info.vendor
+        product = device.info.product
+
+        if not self._detection_fix and pattern == MozaHidDevice.STALKS:
+            name = f"{device.name} Boxflat"
+            vendor = 0x0001
+            product = 0x0001
+
+        new_device = evdev.UInput(cap, vendor=vendor, product=product, name=device.name)
         device.grab()
         self._virtual_devices[pattern] = new_device
         print(f"Detection fix applied for {device.name}")

--- a/boxflat/hid_handler.py
+++ b/boxflat/hid_handler.py
@@ -496,7 +496,7 @@ class HidHandler(EventDispatcher):
         product = device.info.product
 
         if pattern == MozaHidDevice.STALKS:
-            name = f"{device.name} Boxflat"
+            name = "Boxflat Multifunction Stalks"
             vendor = 0x0001
             product = 0x0001
 

--- a/boxflat/hid_handler.py
+++ b/boxflat/hid_handler.py
@@ -459,8 +459,11 @@ class HidHandler(EventDispatcher):
 
 
     def detection_fix(self, pattern: str, enabled: bool=True) -> None:
+        device = self._devices[pattern]
+
         if not enabled:
             if pattern in self._virtual_devices:
+                print(f"Detection fix disabled for {device.name}")
                 self._virtual_devices.pop(pattern).close()
                 self._devices[pattern].ungrab()
             return
@@ -469,7 +472,6 @@ class HidHandler(EventDispatcher):
             return
 
         # Get device capabilities
-        device = self._devices[pattern]
         cap: dict = device.capabilities()
 
         # Return if detection fix is unnecessary

--- a/boxflat/hid_handler.py
+++ b/boxflat/hid_handler.py
@@ -276,7 +276,7 @@ class HidHandler(EventDispatcher):
             if pattern == MozaHidDevice.STALKS:
                 continue
 
-            self._detection_fix(pattern, enabled)
+            self.detection_fix(pattern, enabled)
 
 
     def _configure_device(self, device: evdev.InputDevice, pattern: str):
@@ -460,10 +460,9 @@ class HidHandler(EventDispatcher):
 
     def detection_fix(self, pattern: str, enabled: bool=True) -> None:
         if not enabled:
-            try:
+            if pattern in self._virtual_devices:
                 self._virtual_devices.pop(pattern).close()
-            except KeyError:
-                pass
+                self._devices[pattern].ungrab()
             return
 
         if pattern is MozaHidDevice.BASE:
@@ -494,7 +493,7 @@ class HidHandler(EventDispatcher):
         vendor = device.info.vendor
         product = device.info.product
 
-        if not self._detection_fix and pattern == MozaHidDevice.STALKS:
+        if pattern == MozaHidDevice.STALKS:
             name = f"{device.name} Boxflat"
             vendor = 0x0001
             product = 0x0001

--- a/boxflat/panels/others.py
+++ b/boxflat/panels/others.py
@@ -76,7 +76,7 @@ class OtherSettings(SettingsPanel):
         fix_row.subscribe(self._settings.write_setting, "moza-detection-fix-enabled")
         fix_row.subscribe(lambda v: self._dispatch("moza-detection-fix-enabled", v))
         fix_row.subscribe(self._hid_handler.set_detection_fix_enabled)
-        fix_row.set_value(self._settings.read_setting("moza-detection-fix-enabled") or True)
+        fix_row.set_value(self._settings.read_setting("moza-detection-fix-enabled"))
 
         # Autostart and background stuff
         hidden = BoxflatSwitchRow("Start hidden")

--- a/boxflat/panels/others.py
+++ b/boxflat/panels/others.py
@@ -75,6 +75,7 @@ class OtherSettings(SettingsPanel):
         self._register_event("moza-detection-fix-enabled")
         fix_row.subscribe(self._settings.write_setting, "moza-detection-fix-enabled")
         fix_row.subscribe(lambda v: self._dispatch("moza-detection-fix-enabled", v))
+        fix_row.subscribe(self._hid_handler.set_detection_fix_enabled)
         fix_row.set_value(self._settings.read_setting("moza-detection-fix-enabled") or True)
 
         # Autostart and background stuff

--- a/boxflat/panels/others.py
+++ b/boxflat/panels/others.py
@@ -47,12 +47,12 @@ class OtherSettings(SettingsPanel):
         self._cm.subscribe("main-get-ble-mode", self._current_row.set_value)
         self._cm.subscribe_connected("base-limit", self._current_row.set_active)
 
-        self._add_row(BoxflatSwitchRow("Base FH5 compatibility mode", "Changes USB product ID"))
+        self._add_row(BoxflatSwitchRow("Base FH5 compatibility mode", "Please, disable this on Linux"))
         self._current_row.subscribe(self._cm.set_setting, "main-set-compat-mode")
         self._cm.subscribe("main-get-compat-mode", self._current_row.set_value)
         self._cm.subscribe_connected("main-get-compat-mode", self._current_row.set_present, +1)
 
-        self._add_row(BoxflatSwitchRow("Pedals FH5 compatibility mode", "Changes USB product ID"))
+        self._add_row(BoxflatSwitchRow("Pedals FH5 compatibility mode", "Please, disable this on Linux"))
         self._current_row.subscribe(self._cm.set_setting, "pedals-compat-mode")
         self._cm.subscribe("pedals-compat-mode", self._current_row.set_value)
         self._cm.subscribe_connected("pedals-compat-mode", self._current_row.set_present, +1)
@@ -67,6 +67,15 @@ class OtherSettings(SettingsPanel):
         brake_row.subscribe(self._settings.write_setting, "brake-calibration-enabled")
         brake_row.subscribe(lambda v: self._dispatch("brake-calibration-enabled", v))
         brake_row.set_value(self._settings.read_setting("brake-calibration-enabled"))
+
+        fix_row = BoxflatSwitchRow("Enable Moza detection fixes", "Not needed with Proton 10+")
+        self._fix_row = fix_row
+        self._add_row(fix_row)
+
+        self._register_event("moza-detection-fix-enabled")
+        fix_row.subscribe(self._settings.write_setting, "moza-detection-fix-enabled")
+        fix_row.subscribe(lambda v: self._dispatch("moza-detection-fix-enabled", v))
+        fix_row.set_value(self._settings.read_setting("moza-detection-fix-enabled") or True)
 
         # Autostart and background stuff
         hidden = BoxflatSwitchRow("Start hidden")


### PR DESCRIPTION
Except Multi function stalks where we rely on the virtual device.

Change the name, vid, pid of virtual stalks 