### PR TITLE
Add default preset functionality

### DIFF
--- a/boxflat/panels/presets.py
+++ b/boxflat/panels/presets.py
@@ -27,6 +27,7 @@ class PresetSettings(SettingsPanel):
         self._presets_path = os.path.join(self._settings.get_path(), "presets")
         self._presets_list_group = None
         self._presets = []
+        self._default_preset = None
         super().__init__("Presets", button_callback, connection_manager)
         self.list_presets()
 
@@ -90,10 +91,10 @@ class PresetSettings(SettingsPanel):
         row = BoxflatSwitchRow("H-Pattern Shifter")
         expander.add_row(row)
         row.set_value(0)
-        row.set_active(0)
+        row.set_active(0, off_when_inactive=True)
         row.set_value(self._settings.read_setting("presets-include-hpattern"))
         row.subscribe(self._settings.write_setting, "presets-include-hpattern")
-        self._hpattern.subscribe("active", row.set_active)
+        self._hpattern.subscribe("active", row.set_active, 0, True)
         self._includes["hpattern"] = row.get_value
 
         row = BoxflatSwitchRow("Sequential Shifter")
@@ -115,13 +116,14 @@ class PresetSettings(SettingsPanel):
         row = BoxflatSwitchRow("Multifunction Stalks")
         expander.add_row(row)
         row.set_value(0)
-        row.set_active(0)
+        row.set_active(0, off_when_inactive=True)
         row.set_value(self._settings.read_setting("presets-include-stalks"))
         row.subscribe(self._settings.write_setting, "presets-include-stalks")
-        self._stalks.subscribe("active", row.set_active)
+        self._stalks.subscribe("active", row.set_active, 0, True)
         self._includes["stalks"] = row.get_value
 
         self._observer = process_handler.ProcessObserver()
+        # self._
 
         if Adw.get_minor_version() >= 6:
             self._save_row = Adw.ButtonRow(title="Save")
@@ -237,6 +239,9 @@ class PresetSettings(SettingsPanel):
                 process = pm.get_linked_process()
                 self._observer.register_process(process)
                 self._observer.subscribe(process, self._load_preset, preset_name, True)
+
+                if pm.is_default():
+                    self._default_preset = preset_name
 
 
     def _show_preset_dialog(self, file_name: str):

--- a/boxflat/preset_handler.py
+++ b/boxflat/preset_handler.py
@@ -300,6 +300,24 @@ class MozaPresetHandler(SimpleEventDispatcher):
         self._set_preset_data(data)
 
 
+    def is_default(self) -> bool:
+        data = self._get_preset_data()
+
+        if data is None:
+            return False
+
+        if not "is-default" in data:
+            return False
+
+        return data["is-default"]
+
+
+    def set_default(self) -> None:
+        data = self._get_preset_data()
+        data["is-default"] = True
+        self._set_preset_data(data)
+
+
     def _save_preset(self):
         if not self._path:
             return

--- a/boxflat/preset_handler.py
+++ b/boxflat/preset_handler.py
@@ -312,9 +312,10 @@ class MozaPresetHandler(SimpleEventDispatcher):
         return data["is-default"]
 
 
-    def set_default(self) -> None:
+    def set_default(self, default=True) -> None:
+        default = bool(default)
         data = self._get_preset_data()
-        data["is-default"] = True
+        data["is-default"] = default
         self._set_preset_data(data)
 
 
@@ -350,10 +351,12 @@ class MozaPresetHandler(SimpleEventDispatcher):
                     tries = 3
 
         process_name = self.get_linked_process()
+        default = self.is_default()
         self._set_preset_data(preset_data)
 
         if process_name is not None:
             self.set_linked_process(process_name)
+        self.set_default(default)
 
         self._dispatch()
 

--- a/boxflat/process_handler.py
+++ b/boxflat/process_handler.py
@@ -62,7 +62,8 @@ class ProcessObserver(EventDispatcher):
     def __init__(self) -> None:
         super().__init__()
         self._shutdown = Event()
-        self._current_processs = "no_process_yet"
+        self._current_processs = "empty"
+        self._register_event("no-games")
         Thread(target=self._process_observer_worker, daemon=True).start()
 
 
@@ -73,6 +74,9 @@ class ProcessObserver(EventDispatcher):
 
             for name in self.list_events():
                 if name not in process_list:
+                    if name == self._current_processs:
+                        self._current_processs = "empty"
+                        self._dispatch("no-games")
                     continue
 
                 if name == self._current_processs:
@@ -96,4 +100,7 @@ class ProcessObserver(EventDispatcher):
 
 
     def deregister_all_processes(self) -> None:
-        self._deregister_all_events()
+        for name in self.list_events():
+            if name == "no-games":
+                continue
+            self._deregister_event(name)

--- a/boxflat/widgets/preset_dialog.py
+++ b/boxflat/widgets/preset_dialog.py
@@ -50,6 +50,9 @@ class BoxflatPresetDialog(Adw.Dialog, EventDispatcher):
 
         self._auto_apply.set_value(len(process_name) > 0, mute=False)
 
+        self._default = BoxflatSwitchRow("Default preset", "Activate if no other automatic preset applies")
+        self._default.set_value(self._preset_handler.is_default())
+
         # Place rows in logical order
         page = Adw.PreferencesPage()
         group = Adw.PreferencesGroup(margin_start=10, margin_end=10)
@@ -60,6 +63,10 @@ class BoxflatPresetDialog(Adw.Dialog, EventDispatcher):
         group.add(self._auto_apply)
         group.add(self._auto_apply_name)
         group.add(self._auto_apply_select)
+        page.add(group)
+
+        group = Adw.PreferencesGroup(margin_start=10, margin_end=10)
+        group.add(self._default)
         page.add(group)
 
         # Finally, add all things together
@@ -132,6 +139,8 @@ class BoxflatPresetDialog(Adw.Dialog, EventDispatcher):
         if self._auto_apply.get_value():
             process_name = self._auto_apply_name.get_label()
         self._preset_handler.set_linked_process(process_name)
+
+        self._preset_handler.set_default(self._default.get_value())
 
         current_name = self._name_row.get_text()
         if self._initial_name != current_name:

--- a/boxflat/widgets/row.py
+++ b/boxflat/widgets/row.py
@@ -30,7 +30,7 @@ class BoxflatRow(Adw.ActionRow, SimpleEventDispatcher):
         self._cooldown_increment = 0
 
 
-    def set_active(self, value=1, offset=0) -> bool:
+    def set_active(self, value=1, offset=0, hide_inactive=False) -> bool:
         if value is None:
             return
 
@@ -38,6 +38,8 @@ class BoxflatRow(Adw.ActionRow, SimpleEventDispatcher):
         if value != self.get_active():
             self._active = value
             GLib.idle_add(self.set_sensitive, value)
+            if hide_inactive:
+                GLib.idle_add(self.set_visible, value)
             return True
 
         return False

--- a/boxflat/widgets/switch_row.py
+++ b/boxflat/widgets/switch_row.py
@@ -48,7 +48,7 @@ class BoxflatSwitchRow(BoxflatRow):
 
     def set_active(self, value=1, offset=0, off_when_inactive=False) -> bool:
         tmp = self.get_value()
-        change = super().set_active(value, offset=offset)
+        change = super().set_active(value, offset=offset, hide_inactive=off_when_inactive)
 
         if not change:
             return change


### PR DESCRIPTION
Default preset is loaded if Boxflat can't detect any games (processes) which are linked to presetes with automatic application.

Closes #91